### PR TITLE
Fixed TypeError when adding validators to list

### DIFF
--- a/xappt/models/parameter/parameters.py
+++ b/xappt/models/parameter/parameters.py
@@ -77,6 +77,7 @@ class ParamList(ParameterDescriptor):
             ValidateTypeList,
             ValidateChoiceList,
         ] + kwargs.get('validators', [])
+        kwargs['validators'] = validators
         if choices is None:
             choices = []
-        super().__init__(data_type=list, choices=choices, validators=validators, **kwargs)
+        super().__init__(data_type=list, choices=choices, **kwargs)


### PR DESCRIPTION
Adding the `validators` kwarg to ParamList resulted in this error: `TypeError: __init__() got multiple values for keyword argument 'validators'`